### PR TITLE
Don't add Python dep when cross-compiling by skipping compiling pyc

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_name:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:
@@ -27,7 +27,7 @@ glib:
 gstreamer:
 - '1.22'
 libcurl:
-- '7'
+- '8'
 libiconv:
 - '1'
 libjpeg_turbo:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_arch:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:
@@ -31,7 +31,7 @@ glib:
 gstreamer:
 - '1.22'
 libcurl:
-- '7'
+- '8'
 libiconv:
 - '1'
 libjpeg_turbo:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_name:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:
@@ -27,7 +27,7 @@ glib:
 gstreamer:
 - '1.22'
 libcurl:
-- '7'
+- '8'
 libiconv:
 - '1'
 libjpeg_turbo:

--- a/.ci_support/migrations/gstreamer122.yaml
+++ b/.ci_support/migrations/gstreamer122.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-gstreamer:
-- '1.22'
-migrator_ts: 1674863713.3234591

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,11 +13,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 expat:
 - '2'
 libcurl:
-- '7'
+- '8'
 libiconv:
 - '1'
 libjpeg_turbo:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 expat:
 - '2'
 libcurl:
-- '7'
+- '8'
 libiconv:
 - '1'
 libjpeg_turbo:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,27 +19,11 @@ build:
   run_exports:
     # ABI seems to be stable between minor versions
     - {{ pin_subpackage('wxwidgets', max_pin='x.x') }}
+  skip_compile_pyc:
+    - "*.py"
 
 requirements:
   build:
-    # hmaarrfk
-    # I'm not sure why, without this, I get
-    #
-    # compiling .pyc files...
-    #    File "/Users/runner/miniforge3/lib/python3.9/site-packages/conda_build/post.py", line 296, in post_process
-    #      compile_missing_pyc(files, cwd=prefix, python_exe=python_exe,
-    #    File "/Users/runner/miniforge3/lib/python3.9/site-packages/conda_build/post.py", line 272, in compile_missing_pyc
-    #      call(args + group, cwd=cwd)
-    #    File "/Users/runner/miniforge3/lib/python3.9/subprocess.py", line 349, in call
-    #      with Popen(*popenargs, **kwargs) as p:
-    #    File "/Users/runner/miniforge3/lib/python3.9/subprocess.py", line 951, in __init__
-    #      self._execute_child(args, executable, preexec_fn, close_fds,
-    #    File "/Users/runner/miniforge3/lib/python3.9/subprocess.py", line 1821, in _execute_child
-    #      raise child_exception_type(errno_num, err_msg, err_filename)
-    # OSError: [Errno 86] Bad CPU type in executable: '/Users/runner/miniforge3/conda-bld/wxwidgets_1657415279542
-    # https://github.com/conda/conda-build/issues/686
-    # https://github.com/conda/conda-build/pull/1146
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - gnuconfig  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0001-Remove-host-prefix-suffix-when-cross-compiling.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # ABI seems to be stable between minor versions
     - {{ pin_subpackage('wxwidgets', max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~[ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
There is only one *.py file currently, `share/bakefile/presets/wx_presets.py`, and it's really not necessary to compile it to a pyc (especially because it's doubtful anyone is even using these bakefile files).

This means we can avoid having a python dependency added when cross-compiling, and thus we remove a requirement that the cross-compiled packages need to be installed with the same Python interpreter that happened to be used during the compilation. That means that Python 3.11 has been required to use the most recent linux-aarch64, linux-ppc64le, and osx-arm64 packages, but now it can be installed next to any Python version.